### PR TITLE
Enable VitePress 'deep' outline; fix post spacing

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -25,6 +25,7 @@ export default defineConfig({
   },
   appearance: false,
   themeConfig: {
+      outline: 'deep',
       siteTitle: "Mterczynski's blog",
     nav: [
       { text: 'Home', link: '/' },

--- a/posts/building-tic-tac-toe-javascript.md
+++ b/posts/building-tic-tac-toe-javascript.md
@@ -13,6 +13,7 @@ date: 2024-09-08
 - [Adding a reset button](#adding-a-reset-button)
 - [Links to playable game and repository](#links-to-playable-game-and-repository)
 
+
 ### Introduction
 
 Tic Tac Toe is an excellent project for beginners in game development. Its simplicity makes it approachable, yet it encompasses key fundamental concepts essential for developing more complex games.


### PR DESCRIPTION
Add themeConfig outline: 'deep' to .vitepress/config.mts to show deeper heading levels in the site outline. Also insert a blank line in the Tic Tac Toe post markdown to correct spacing/formatting before the Introduction heading.